### PR TITLE
Vpalepu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 
+*.json
 *.exec
 /bin
 *.class

--- a/README.md
+++ b/README.md
@@ -67,3 +67,8 @@ java -javaagent:lib/org.jacoco.agent-0.7.4.201502262128-runtime.jar=destfile=jac
 - Instruction and Branch counters are **disregarded** in DENSE formatting.
 - DENSE formatting encodes 16 (at most) line-statuses into a single 32-bit integer.
 - DENSE formatting is implemented in LinesStatusCoder.
+
+## Running CoverageJsonReader
+
+0. Compile tacoco as stated in the subsection [Compiling ExecAnalyzer](#compiling-execanalyzer).
+1. Use the following maven command on the command line to execute the CoverageJsonReader: `mvn exec:java -Preader -Dexec.args="/path/to/your/json/output-file.json"`

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,22 @@
 				</plugins>
 			</build>
 		</profile>
+		
+		<profile>
+			<id>reader</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>exec-maven-plugin</artifactId>
+						<version>1.4.0</version>
+						<configuration>
+							<mainClass>org.spideruci.tacoco.reporting.CoverageJsonReader</mainClass>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 
 </project>

--- a/src/main/java/org/spideruci/tacoco/TacocoRunner.java
+++ b/src/main/java/org/spideruci/tacoco/TacocoRunner.java
@@ -17,27 +17,11 @@ import java.util.ArrayList;
 import org.junit.runner.JUnitCore;
 
 
-public final class TacocoRunner
-{
-	public static void main(String[] args)
-	{
-//		int sleepLength = 2000;
-//		System.out.println("Testing Thread.sleep()");
-//		System.out.println("Going to sleep for "+sleepLength+" ms.");
-//		try
-//		{
-//			Thread.sleep(sleepLength);
-//		}
-//		catch(InterruptedException e)
-//		{
-//			System.out.println(e.getMessage());
-//		}
-//		System.out.println("Done sleeping.");
-		
+public final class TacocoRunner {
+	public static void main(String[] args) {
 		try {
 			addPath(args[0]);
 		} catch (Exception e1) {
-			// TODO Auto-generated catch block
 			e1.printStackTrace();
 		}
 		JUnitCore core = new JUnitCore();
@@ -49,7 +33,6 @@ public final class TacocoRunner
 			} catch (ClassNotFoundException e) {
 				e.printStackTrace();
 			}
-
 		}
 		
 		System.out.println(System.getProperty("java.class.path"));
@@ -85,5 +68,4 @@ public final class TacocoRunner
 		}
 		return ret;
 	}			
-
 }

--- a/src/main/java/org/spideruci/tacoco/reporting/CoverageJsonPrinter.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/CoverageJsonPrinter.java
@@ -1,5 +1,7 @@
 package org.spideruci.tacoco.reporting;
 
+import static org.spideruci.tacoco.reporting.data.SourceFileCoverageBuilder.*;
+
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -9,7 +11,6 @@ import org.jacoco.core.analysis.IPackageCoverage;
 import org.jacoco.core.analysis.ISourceFileCoverage;
 import org.spideruci.tacoco.reporting.data.SourceFileCoverage;
 import org.spideruci.tacoco.reporting.data.SourceFileCoverage.LineCoverageFormat;
-import org.spideruci.tacoco.reporting.data.SourceFileCoverageBuilder;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -38,30 +39,38 @@ public class CoverageJsonPrinter implements ICoveragePrintable {
     out.println(coverage.getName());
   }
   
+  @SuppressWarnings("rawtypes")
   @Override
   public void printCoverage() {
     
     ArrayList<ISourceFileCoverage> sourcefilesCovergae = 
         amassSourcefilesCoverage();
-    Object[] sourcefiles = coverage(format, sourcefilesCovergae);
+    SourceFileCoverage[] sourcefiles = coverage(format, sourcefilesCovergae);
     out.print(gson.toJson(sourcefiles));
   }
   
-    private Object[] coverage(LineCoverageFormat format, ArrayList<ISourceFileCoverage> sourcefilesCoverage) {
+    @SuppressWarnings("rawtypes")
+    private SourceFileCoverage[] coverage(LineCoverageFormat format, 
+        ArrayList<ISourceFileCoverage> sourcefilesCoverage) {
       int sourcefileCount = sourcefilesCoverage.size();
       switch (format) {
       case LOOSE:
       {
-        ISourceFileCoverage[] sourcefiles = sourcefilesCoverage.toArray(
-            new ISourceFileCoverage[sourcefileCount]);
+        SourceFileCoverage[] sourcefiles = new SourceFileCoverage[sourcefileCount];
+        int counter = 0;
+        for(ISourceFileCoverage srcCov : sourcefilesCoverage) {
+          sourcefiles[counter] = buildLoose(srcCov, coverage.getName());
+          counter ++;
+        }
         return sourcefiles;
+        
       }
       case COMPACT:
       {
         SourceFileCoverage[] sourcefiles = new SourceFileCoverage[sourcefileCount];
         int counter = 0;
-        for(ISourceFileCoverage cov : sourcefilesCoverage) {
-          sourcefiles[counter] = SourceFileCoverageBuilder.buildCompact(cov);
+        for(ISourceFileCoverage srcCov : sourcefilesCoverage) {
+          sourcefiles[counter] = buildCompact(srcCov, coverage.getName());
           counter ++;
         }
         return sourcefiles;
@@ -70,8 +79,8 @@ public class CoverageJsonPrinter implements ICoveragePrintable {
       {
         SourceFileCoverage[] sourcefiles = new SourceFileCoverage[sourcefileCount];
         int counter = 0;
-        for(ISourceFileCoverage cov : sourcefilesCoverage) {
-          sourcefiles[counter] = SourceFileCoverageBuilder.buildDense(cov);
+        for(ISourceFileCoverage srcCov : sourcefilesCoverage) {
+          sourcefiles[counter] = buildDense(srcCov, coverage.getName());
           counter ++;
         }
         return sourcefiles;

--- a/src/main/java/org/spideruci/tacoco/reporting/CoverageJsonReader.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/CoverageJsonReader.java
@@ -2,14 +2,11 @@ package org.spideruci.tacoco.reporting;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
-import org.jacoco.core.analysis.ILine;
 import org.spideruci.tacoco.reporting.data.CoverageMatrix;
 import org.spideruci.tacoco.reporting.data.CoverageMatrix.SourceFile;
 import org.spideruci.tacoco.reporting.data.LineCoverageCoder;

--- a/src/main/java/org/spideruci/tacoco/reporting/CoverageJsonReader.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/CoverageJsonReader.java
@@ -1,0 +1,103 @@
+package org.spideruci.tacoco.reporting;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+
+import org.jacoco.core.analysis.ILine;
+import org.spideruci.tacoco.reporting.data.CoverageMatrix;
+import org.spideruci.tacoco.reporting.data.CoverageMatrix.SourceFile;
+import org.spideruci.tacoco.reporting.data.LineCoverageCoder;
+import org.spideruci.tacoco.reporting.data.SourceFileCoverage;
+import org.spideruci.tacoco.reporting.data.SourceFileCoverage.LineCoverageFormat;
+
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonReader;
+
+public class CoverageJsonReader {
+  private final File jsonFile;
+  
+  public CoverageJsonReader(final File json) {
+    this.jsonFile = json;
+  }
+
+  @SuppressWarnings("rawtypes")
+  public SourceFileCoverage[][] read() throws FileNotFoundException {
+    SourceFileCoverage[][] covMatrix = null;
+    Gson gson = new Gson();
+    JsonReader reader = new JsonReader(new InputStreamReader(new FileInputStream(jsonFile)));
+    covMatrix = gson.fromJson(reader, SourceFileCoverage[][].class);
+    return covMatrix;
+  }
+  
+  @SuppressWarnings("rawtypes")
+  public static void main(String[] args) throws FileNotFoundException {
+    
+    CoverageJsonReader reader = new CoverageJsonReader(new File(args[0]));
+    SourceFileCoverage[][] data = reader.read();
+    LineCoverageFormat covFormat = data[0][0].getFormat();
+    LineCoverageCoder coder = new LineCoverageCoder();
+    int testcount = data.length;
+    CoverageMatrix covMat = new CoverageMatrix(covFormat, testcount); 
+
+    int count = 0;
+    for(SourceFileCoverage[] files : data) {
+      String testCaseName = null;
+      if((testCaseName = reader.getTestCaseName(files)) == null) {
+        System.err.printf("Ignoring session#%d%n", count);
+        count += 1;
+        continue;
+      }
+      
+      covMat.indexTestName(testCaseName);
+      
+      System.out.println(files.length);
+      ArrayList<Integer> lineCoverages = new ArrayList<>();
+      for(SourceFileCoverage file : files) {
+        covMat.indexSourceFile(new SourceFile(file.getPackageName() + file.getFileName(), file.getFirstLine(), file.getLastLine()));
+        System.out.println(file.getFileName() + "\t" + file.getLastLine());
+        for(Object line : file.getLinesCoverage()) {
+          if(covFormat == LineCoverageFormat.LOOSE) {
+            int linecov = coder.encode((ILine)line);
+            lineCoverages.add(linecov);
+          } else {
+            int lineIntValue = reader.readDoubleObjectAsInt(line);
+            lineCoverages.add(lineIntValue);
+          }
+        }
+        int[] codedLineCoverage = new int[lineCoverages.size()];
+        for(int i = 0; i < codedLineCoverage.length; i += 1) {
+          codedLineCoverage[i] = lineCoverages.get(i);
+        }
+        covMat.addStmtCoverage(testCaseName, codedLineCoverage);
+        
+      }
+      System.out.println();
+    }
+    
+    covMat.printMatrix();
+  }
+  
+  int readDoubleObjectAsInt(Object line) {
+    Double lineDoubleValue = (Double) line; 
+    long lineLongValue = lineDoubleValue.longValue();
+    int lineIntValue = (int) lineLongValue;
+    return lineIntValue;
+  }
+  
+  @SuppressWarnings({"rawtypes"})
+  private String getTestCaseName(SourceFileCoverage[] files) {
+    
+    String testCase = files[0].getSessionName();
+    
+    for(int i = 1; i <= files.length - 1; i += 1) {
+      String nextTestCase = files[i].getSessionName();
+      if(!testCase.equals(nextTestCase)) return null;
+    }
+    
+    return testCase;
+  }
+  
+}

--- a/src/main/java/org/spideruci/tacoco/reporting/CoverageJsonReader.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/CoverageJsonReader.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.jacoco.core.analysis.ILine;
 import org.spideruci.tacoco.reporting.data.CoverageMatrix;
@@ -21,6 +22,19 @@ import com.google.gson.JsonSyntaxException;
 import com.google.gson.stream.JsonReader;
 
 public class CoverageJsonReader {
+  
+  public static void main(String[] args) throws IOException {
+    File jsonFile = new File(args[0]);
+    LineCoverageFormat covFormat = readCoverageFormat(jsonFile);
+    InputStreamReader jsonIn = 
+        new InputStreamReader(new FileInputStream(jsonFile));
+    JsonReader jsonreader = new JsonReader(jsonIn);
+    CoverageJsonReader reader = new CoverageJsonReader(jsonreader);;
+    CoverageMatrix covMat = reader.read(covFormat);
+    covMat.printMatrix();
+    covMat.dumpMatrix();
+  }
+  
   private final JsonReader jsonReader;
   private final Gson gson;
   
@@ -75,51 +89,19 @@ public class CoverageJsonReader {
   }
 
   @SuppressWarnings("rawtypes")
-  public SourceFileCoverage[][] read() throws IOException {
-    SourceFileCoverage[][] sourcefileCovMatrix = null;
-    
-    List<SourceFileCoverage> messages = new ArrayList<SourceFileCoverage>();
-    jsonReader.beginArray();
-    while (jsonReader.hasNext()) {
-      jsonReader.beginArray();
-      boolean hasNext = jsonReader.hasNext();
-      while (hasNext) {
-        SourceFileCoverage message = gson.fromJson(jsonReader, SourceFileCoverage.class);
-        messages.add(message);
-        System.out.println(message.getSessionName() + " " + message);
-        hasNext = jsonReader.hasNext();
-      }
-      jsonReader.endArray();
-      System.out.println();
-    }
-    jsonReader.endArray();
-    jsonReader.close();
-    
-    return sourcefileCovMatrix;
-  }
-  
-  @SuppressWarnings("rawtypes")
-  public static void main(String[] args) throws IOException {
-    File jsonFile = new File(args[0]);
-    LineCoverageFormat covFormat = readCoverageFormat(jsonFile);
-    
-    InputStreamReader jsonIn = new InputStreamReader(new FileInputStream(jsonFile));
-    JsonReader jsonreader = new JsonReader(jsonIn);
-    CoverageJsonReader reader = new CoverageJsonReader(jsonreader);;
-    
+  public CoverageMatrix read(LineCoverageFormat covFormat) throws IOException {
+    int count = 0;
     LineCoverageCoder coder = new LineCoverageCoder();
     CoverageMatrix covMat = new CoverageMatrix(covFormat); 
-
-    int count = 0;
     
-    reader.startReading();
-    while(reader.hasNext()) {
+    this.startReading();
+    while(this.hasNext()) {
       String testCaseName = null;
       ArrayList<Integer> lineCoverages = new ArrayList<>();
-      reader.startReadingTestCase();
-      while(reader.hasNext()) {
-        SourceFileCoverage sourcefile = reader.readNextSourceFileCoverage();
-        
+      this.startReadingTestCase();
+      while(this.hasNext()) {
+        SourceFileCoverage sourcefile = this.readNextSourceFileCoverage();
+        assert sourcefile != null; // hasNext() should have taken care of this.
         String currTestCaseName = sourcefile.getSessionName();
         if(testCaseName == null) {
           testCaseName = currTestCaseName;
@@ -139,20 +121,28 @@ public class CoverageJsonReader {
         SourceFile source = new SourceFile(filename, firstLine, lastLine);
         covMat.indexSourceFile(source);
         
-        System.out.println(sourcefile.getFileName() + "\t" + sourcefile.getLastLine());
+        System.out.printf("%s\t%s%n", sourcefile.getFileName(), 
+            sourcefile.getLastLine());
         
         for(Object line : sourcefile.getLinesCoverage()) {
           if(covFormat == LineCoverageFormat.LOOSE) {
-            int linecov = coder.encode((ILine)line);
+            Map insnCounter = (Map) ((Map)line).get("instructions");
+            int ic = readDoubleObjectAsInt(insnCounter.get("covered"));
+            int im = readDoubleObjectAsInt(insnCounter.get("missed"));
+            Map branchCounter = (Map) ((Map)line).get("branches");
+            int bc = readDoubleObjectAsInt(branchCounter.get("covered"));
+            int bm = readDoubleObjectAsInt(branchCounter.get("missed"));
+            int linecov = coder.encode(ic, im, bc, bm);
             lineCoverages.add(linecov);
           } else {
-            int lineIntValue = reader.readDoubleObjectAsInt(line);
+            int lineIntValue = this.readDoubleObjectAsInt(line);
             lineCoverages.add(lineIntValue);
           }
         }
         
       }
-      reader.endReadingTestCase();
+      this.endReadingTestCase();
+      System.out.println();
       if(lineCoverages == null) continue;
       
       int[] codedLineCoverage = new int[lineCoverages.size()];
@@ -162,7 +152,7 @@ public class CoverageJsonReader {
       covMat.addStmtCoverage(testCaseName, codedLineCoverage);
     }
     
-    covMat.printMatrix();
+    return covMat;
   }
   
   int readDoubleObjectAsInt(Object line) {
@@ -170,19 +160,5 @@ public class CoverageJsonReader {
     long lineLongValue = lineDoubleValue.longValue();
     int lineIntValue = (int) lineLongValue;
     return lineIntValue;
-  }
-  
-  @SuppressWarnings({"rawtypes"})
-  private String getTestCaseName(SourceFileCoverage[] files) {
-    
-    String testCase = files[0].getSessionName();
-    
-    for(int i = 1; i <= files.length - 1; i += 1) {
-      String nextTestCase = files[i].getSessionName();
-      if(!testCase.equals(nextTestCase)) return null;
-    }
-    
-    return testCase;
-  }
-  
+  }  
 }

--- a/src/main/java/org/spideruci/tacoco/reporting/ExecAnalyzer.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/ExecAnalyzer.java
@@ -59,13 +59,9 @@ public final class ExecAnalyzer {
 		
 		reader.setSessionInfoVisitor(new ISessionInfoVisitor() {
 			public void visitSessionInfo(final SessionInfo info) {
-			  String sessionName = String.format("Session \"%s\": %s - %s", 
-			      info.getId(),
-            new Date(info.getStartTimeStamp()),
-            new Date(info.getDumpTimeStamp()));
-			  parser.resetExecDataStore();
-			  parser.setCoverageTitle(sessionName);
-				System.out.println("\n" + sessionName);
+			  String nextSessionName = info.getId();
+			  parser.resetExecDataStore(nextSessionName);
+				System.out.println("\n" + nextSessionName);
 			}
 		});
 		

--- a/src/main/java/org/spideruci/tacoco/reporting/ExecAnalyzer.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/ExecAnalyzer.java
@@ -72,6 +72,7 @@ public final class ExecAnalyzer {
 		reader.setExecutionDataVisitor(parser);
 		reader.read();
 		in.close();
+		parser.close();
 	}
 	
 	

--- a/src/main/java/org/spideruci/tacoco/reporting/ExecAnalyzer.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/ExecAnalyzer.java
@@ -5,7 +5,6 @@ import static org.spideruci.tacoco.reporting.ExecDataPrintManager.createPrintMan
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.Date;
 
 import org.jacoco.core.data.ExecutionDataReader;
 import org.jacoco.core.data.ISessionInfoVisitor;

--- a/src/main/java/org/spideruci/tacoco/reporting/ExecAnalyzer.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/ExecAnalyzer.java
@@ -22,32 +22,39 @@ public final class ExecAnalyzer {
 	 * @throws IOException
 	 */
 	public static void main(final String[] args) throws IOException {
-	  File projectRoot = new File(args[0]);
-	  String execFile = args[1];
-	  String jsonFilePath = args.length < 3 ? null : args[2];
-	  String format = 
-	      (args.length < 4 || args[3] == null) 
-	      ? null : args[3].trim().toUpperCase();
-	  String prettyPrint = 
-	      (args.length < 5 || args[4] == null) 
-	      ? null : args[4].trim().toLowerCase();
-	  ExecDataPrintManager printManager = 
-	      createPrintManager(jsonFilePath, format, prettyPrint);
-	  ExecutionDataParser parser = 
-	      new ExecutionDataParser(projectRoot, printManager);
-	  ExecAnalyzer execAnalyzer = new ExecAnalyzer();
-	  execAnalyzer.dumpContent(execFile, parser, jsonFilePath, format, prettyPrint);
+	  ExecAnalyzer execAnalyzer = processArgs(args);
+	  execAnalyzer.dumpContent();
+	}
+	
+  	private static ExecAnalyzer processArgs(String[] args) {
+  	  File projectRoot = new File(args[0]);
+      File execFile = new File(args[1]);
+      String jsonFilePath = args.length < 3 ? null : args[2];
+      String format = 
+          (args.length < 4 || args[3] == null) 
+          ? null : args[3].trim().toUpperCase();
+      String prettyPrint = 
+          (args.length < 5 || args[4] == null) 
+          ? null : args[4].trim().toLowerCase();
+      ExecDataPrintManager printManager = 
+          createPrintManager(jsonFilePath, format, prettyPrint);
+      ExecutionDataParser parser = 
+          new ExecutionDataParser(projectRoot, printManager);
+      ExecAnalyzer execAnalyzer = new ExecAnalyzer(execFile, parser);
+  	  return execAnalyzer;
+  	}
+	
+	private final File execFile;
+	private final ExecutionDataParser parser;
+	
+	public ExecAnalyzer(File file, ExecutionDataParser parser) {
+	  this.execFile = file;
+	  this.parser = parser;
 	}
 
-	private void dumpContent(final String file,
-	    final ExecutionDataParser parser,
-	    final String jsonFilePath,
-	    final String formatString,
-	    final String prettyString) throws IOException {
-		System.out.printf("exec:%s,json:%s,format:%s,pretty:%s%n", 
-		    file, jsonFilePath, formatString, prettyString);
-		
-		final FileInputStream in = new FileInputStream(file);
+	public void dumpContent() throws IOException {
+	  System.out.printf("exec:%s%n", execFile);
+		final FileInputStream in = new FileInputStream(execFile);
 		final ExecutionDataReader reader = new ExecutionDataReader(in);
 		
 		reader.setSessionInfoVisitor(new ISessionInfoVisitor() {
@@ -66,4 +73,6 @@ public final class ExecAnalyzer {
 		reader.read();
 		in.close();
 	}
+	
+	
 }

--- a/src/main/java/org/spideruci/tacoco/reporting/ExecAnalyzer.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/ExecAnalyzer.java
@@ -64,9 +64,6 @@ public final class ExecAnalyzer {
 		
 		reader.setExecutionDataVisitor(parser);
 		reader.read();
-		
-		
 		in.close();
-		System.out.println();
 	}
 }

--- a/src/main/java/org/spideruci/tacoco/reporting/ExecDataPrintManager.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/ExecDataPrintManager.java
@@ -1,6 +1,7 @@
 package org.spideruci.tacoco.reporting;
 
-import java.io.FileNotFoundException;
+import java.io.File;
+import java.io.IOException;
 import java.io.PrintStream;
 
 import org.spideruci.tacoco.reporting.data.SourceFileCoverage.LineCoverageFormat;
@@ -11,19 +12,31 @@ public class ExecDataPrintManager {
   private final LineCoverageFormat format;
   private final boolean isPrettyPrint;
   
+  @SuppressWarnings("resource")
   public static ExecDataPrintManager createPrintManager(final String jsonFilePath,
       final String formatString,
       final String prettyString) {
-    PrintStream out;
-    try {
-      out = (jsonFilePath == null || jsonFilePath.isEmpty())
-      ? System.out : new PrintStream(jsonFilePath);
-    } catch (FileNotFoundException e) {
+    
+    PrintStream out = null;
+    
+    if(jsonFilePath == null || jsonFilePath.isEmpty()) {
       out = System.out;
-      System.err.printf("%s not found. "
-          + "Switching to Standard out.%n", jsonFilePath);
-      e.printStackTrace();
+    } else {
+      File jsonFile = new File(jsonFilePath);
+      try {
+        jsonFile.createNewFile();
+        if(jsonFile.exists() && !jsonFile.isFile()) {
+          System.err.println("Json file path is not a file. Switching to STDOUT");
+          out = System.out;
+        } else {
+          out = new PrintStream(jsonFile);
+        }
+      } catch (IOException e) {
+        out = System.out;
+        e.printStackTrace();
+      }
     }
+    
     LineCoverageFormat format = 
         (formatString == null || formatString.isEmpty()) 
         ? LineCoverageFormat.DENSE : LineCoverageFormat.valueOf(formatString);

--- a/src/main/java/org/spideruci/tacoco/reporting/ExecDataPrintManager.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/ExecDataPrintManager.java
@@ -16,9 +16,7 @@ public class ExecDataPrintManager {
   public static ExecDataPrintManager createPrintManager(final String jsonFilePath,
       final String formatString,
       final String prettyString) {
-    
     PrintStream out = null;
-    
     if(jsonFilePath == null || jsonFilePath.isEmpty()) {
       out = System.out;
     } else {
@@ -26,7 +24,8 @@ public class ExecDataPrintManager {
       try {
         jsonFile.createNewFile();
         if(jsonFile.exists() && !jsonFile.isFile()) {
-          System.err.println("Json file path is not a file. Switching to STDOUT");
+          System.err.printf("Json-output destination (%s) is not a file. "
+              + "Switching to STDOUT%n", jsonFile.getPath());
           out = System.out;
         } else {
           out = new PrintStream(jsonFile);
@@ -45,6 +44,8 @@ public class ExecDataPrintManager {
         ? false : Boolean.parseBoolean(prettyString);
     ExecDataPrintManager printMgr = 
         new ExecDataPrintManager(out, format, isPretty);
+    System.out.printf("json:%s,format:%s,pretty:%s%n", 
+        jsonFilePath, formatString, prettyString);
     return printMgr;
   }
   

--- a/src/main/java/org/spideruci/tacoco/reporting/ExecDataPrintManager.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/ExecDataPrintManager.java
@@ -56,7 +56,7 @@ public class ExecDataPrintManager {
     this.isPrettyPrint = isPrettyPrint;
   }
   
-  public void closePrintStream() {
+  public void closeJsonStream() {
     jsonOut.flush();
     jsonOut.close();
   }

--- a/src/main/java/org/spideruci/tacoco/reporting/ExecutionDataParser.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/ExecutionDataParser.java
@@ -2,6 +2,8 @@ package org.spideruci.tacoco.reporting;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
+
 import org.jacoco.core.analysis.Analyzer;
 import org.jacoco.core.analysis.CoverageBuilder;
 import org.jacoco.core.analysis.IBundleCoverage;
@@ -43,7 +45,7 @@ public class ExecutionDataParser implements IExecutionDataVisitor {
     execDataStore.put(data);
   }
   
-  public void resetExecDataStore() {
+  public void resetExecDataStore(String nextSessionName) {
     if(execDataStore.getContents().size() == 0) {
       execDataStore = new ExecutionDataStore();
       return;
@@ -52,6 +54,7 @@ public class ExecutionDataParser implements IExecutionDataVisitor {
     try {
       System.out.printf("analyzing exec-data for: %s%n", coverageTitle);
       IBundleCoverage coverage = this.analyzeStructure(execDataStore);
+      this.setCoverageTitle(nextSessionName);
       printCoverage(coverage);
     } catch (IOException e) {
       e.printStackTrace();
@@ -65,8 +68,18 @@ public class ExecutionDataParser implements IExecutionDataVisitor {
     ICoveragePrintable printer = 
         new CoverageJsonPrinter(coverage, printManager.jsonOut(),
             printManager.isPrettyPrint(), printManager.format());
-    printer.printCoverageTitle();
+    PrintStream out = printManager.jsonOut();
+    if(count == 0) {
+      out.print('[');
+    }
     printer.printCoverage();
+    if(this.coverageTitle == null
+        || this.coverageTitle.isEmpty()
+        || this.coverageTitle.equals("end")) {
+      out.print("]");
+    } else {
+      out.println(",");
+    }
     System.out.printf("completed printing coverage bundle for %s.%n", coverage.getName());
     System.out.printf("completed printing %d coverage bundle(s).%n%n", ++count);
   }

--- a/src/main/java/org/spideruci/tacoco/reporting/ExecutionDataParser.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/ExecutionDataParser.java
@@ -1,8 +1,7 @@
 package org.spideruci.tacoco.reporting;
+
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-
 import org.jacoco.core.analysis.Analyzer;
 import org.jacoco.core.analysis.CoverageBuilder;
 import org.jacoco.core.analysis.IBundleCoverage;
@@ -38,9 +37,9 @@ public class ExecutionDataParser implements IExecutionDataVisitor {
 
   public void visitClassExecution(final ExecutionData data) {
     if(data == null) return;
-    System.out.printf("adding exec-data for: %s %d%n", 
-        data.getName(), 
-        getHitCount(data.getProbes()));
+//    System.out.printf("adding exec-data for: %s %d%n", 
+//        data.getName(), 
+//        getHitCount(data.getProbes()));
     execDataStore.put(data);
   }
   
@@ -83,6 +82,7 @@ public class ExecutionDataParser implements IExecutionDataVisitor {
     return coverageBuilder.getBundle(coverageTitle);
   }
   
+  @SuppressWarnings("unused")
   private int getHitCount(final boolean[] data) {
     int count = 0;
     for (final boolean hit : data) {

--- a/src/main/java/org/spideruci/tacoco/reporting/ExecutionDataParser.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/ExecutionDataParser.java
@@ -75,7 +75,8 @@ public class ExecutionDataParser implements IExecutionDataVisitor {
     this.coverageTitle = title;
   }
   
-  private IBundleCoverage analyzeStructure(final ExecutionDataStore data) throws IOException {
+  private IBundleCoverage analyzeStructure(final ExecutionDataStore data) 
+      throws IOException {
     final CoverageBuilder coverageBuilder = new CoverageBuilder();
     final Analyzer analyzer = new Analyzer(data, coverageBuilder);
     analyzer.analyzeAll(classesDirectory);
@@ -91,6 +92,10 @@ public class ExecutionDataParser implements IExecutionDataVisitor {
       }
     }
     return count;
+  }
+
+  public void close() {
+    this.printManager.closeJsonStream();
   }
 
 }

--- a/src/main/java/org/spideruci/tacoco/reporting/ReportGenerator.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/ReportGenerator.java
@@ -13,8 +13,6 @@ package org.spideruci.tacoco.reporting;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.jacoco.core.analysis.Analyzer;
 import org.jacoco.core.analysis.CoverageBuilder;

--- a/src/main/java/org/spideruci/tacoco/reporting/data/CoverageMatrix.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/data/CoverageMatrix.java
@@ -64,7 +64,7 @@ public class CoverageMatrix {
   }
   
   public void addStmtCoverage(String testName, int[] coverage) {
-    int index = testNameIndex.get(testName); // TODO
+    @SuppressWarnings("unused") int index = testNameIndex.get(testName);
     testStmtmatrix.add(coverage);
   }
   

--- a/src/main/java/org/spideruci/tacoco/reporting/data/CoverageMatrix.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/data/CoverageMatrix.java
@@ -11,14 +11,14 @@ public class CoverageMatrix {
   private final HashMap<SourceFile, Integer> sourceFileIndex;
   private final ArrayList<Integer> sourceFileRanges;
   private final LineCoverageFormat format;
-  private final int[][] testStmtmatrix;
+  private final ArrayList<int[]> testStmtmatrix;
   
-  public CoverageMatrix(LineCoverageFormat fmt, int testCount) {
+  public CoverageMatrix(LineCoverageFormat fmt) {
     testNameIndex = new HashMap<>();
     sourceFileIndex = new HashMap<>();
     sourceFileRanges = new ArrayList<>();
     format = fmt;
-    testStmtmatrix = new int[testCount][];
+    testStmtmatrix = new ArrayList<>();
   }
 
   private int nextAvailSourceId = 0;
@@ -62,8 +62,8 @@ public class CoverageMatrix {
   }
   
   public void addStmtCoverage(String testName, int[] coverage) {
-    int index = testNameIndex.get(testName);
-    testStmtmatrix[index] = coverage;
+    int index = testNameIndex.get(testName); // TODO
+    testStmtmatrix.add(coverage);
   }
   
   public void printMatrix() {

--- a/src/main/java/org/spideruci/tacoco/reporting/data/CoverageMatrix.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/data/CoverageMatrix.java
@@ -1,0 +1,132 @@
+package org.spideruci.tacoco.reporting.data;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import org.spideruci.tacoco.reporting.data.SourceFileCoverage.LineCoverageFormat;
+
+public class CoverageMatrix {
+  
+  private final HashMap<String, Integer> testNameIndex;
+  private final HashMap<SourceFile, Integer> sourceFileIndex;
+  private final ArrayList<Integer> sourceFileRanges;
+  private final LineCoverageFormat format;
+  private final int[][] testStmtmatrix;
+  
+  public CoverageMatrix(LineCoverageFormat fmt, int testCount) {
+    testNameIndex = new HashMap<>();
+    sourceFileIndex = new HashMap<>();
+    sourceFileRanges = new ArrayList<>();
+    format = fmt;
+    testStmtmatrix = new int[testCount][];
+  }
+
+  private int nextAvailSourceId = 0;
+  public int indexSourceFile(SourceFile source) {
+    Integer sourceId = sourceFileIndex.get(source);
+    if(sourceId != null) {
+      return sourceId;
+    } 
+
+    sourceFileIndex.put(source, nextAvailSourceId);
+    nextAvailSourceId += 1;
+    return sourceFileIndex.get(source);
+  }
+
+  private int nextAvailTestId = 0;
+  public int indexTestName(String testName) {
+    Integer testId = testNameIndex.get(testName);
+    if(testId != null) {
+      return testId;
+    } 
+
+    testNameIndex.put(testName, nextAvailTestId);
+    nextAvailTestId += 1;
+    return testNameIndex.get(testName);
+  }
+
+  /**
+   * @return the sourceFileRanges
+   */
+  public void indexSourceFileRanges(SourceFile source, int rangeEnd) {
+    int sourceId = sourceFileIndex.get(source);
+    assert sourceId == sourceFileRanges.size();
+    sourceFileRanges.add(rangeEnd);
+  }
+  
+  /**
+   * @return the format
+   */
+  public LineCoverageFormat getFormat() {
+    return format;
+  }
+  
+  public void addStmtCoverage(String testName, int[] coverage) {
+    int index = testNameIndex.get(testName);
+    testStmtmatrix[index] = coverage;
+  }
+  
+  public void printMatrix() {
+    for(int[] test : testStmtmatrix) {
+      for(int codedCoverage : test) {
+        System.out.print(codedCoverage + "\t");
+      }
+      System.out.println();
+    }
+  }
+
+  public static class SourceFile {
+    private final String fullName;
+    private final int firstLine;
+    private final int lastLine;
+    
+    public SourceFile(String fullName, int firstLine, int lastLine) {
+      this.fullName = fullName;
+      this.firstLine = firstLine;
+      this.lastLine = lastLine;
+    }
+    
+    public String getFullName() {
+      return this.fullName;
+    }
+
+    @Override
+    public int hashCode() {
+      return this.fullName.hashCode();
+    }
+    
+    @Override
+    public boolean equals(Object object) {
+      if(object == null) {
+        return false;
+      }
+      
+      if(!(object instanceof SourceFile)) {
+        return false;
+      }
+      
+      SourceFile sourceFile = (SourceFile) object;
+      
+      if(this.fullName.equals(sourceFile.fullName)) {
+        return true;
+      }
+      
+      return false;
+    }
+
+    /**
+     * @return the firstLine
+     */
+    public int getFirstLine() {
+      return firstLine;
+    }
+
+    /**
+     * @return the lastLine
+     */
+    public int getLastLine() {
+      return lastLine;
+    }
+  }
+
+}

--- a/src/main/java/org/spideruci/tacoco/reporting/data/LineCoverageCoder.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/data/LineCoverageCoder.java
@@ -8,7 +8,7 @@ public class LineCoverageCoder {
   private final static int SHIFT = 8; 
   private final static int MASK = 0b11111111;
    
-  int encode(ILine lineCoverage) {
+  public int encode(ILine lineCoverage) {
     int code = 0;
     ICounter insnCounter = lineCoverage.getInstructionCounter();
     code = code | insnCounter.getCoveredCount();
@@ -22,7 +22,7 @@ public class LineCoverageCoder {
     return code;
   }
   
-  int[] decode(int code) {
+  public int[] decode(int code) {
     int bm = code & MASK;
     code = code >>> SHIFT;
     int bc = code & MASK;

--- a/src/main/java/org/spideruci/tacoco/reporting/data/LineCoverageCoder.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/data/LineCoverageCoder.java
@@ -2,6 +2,7 @@ package org.spideruci.tacoco.reporting.data;
 
 import org.jacoco.core.analysis.ICounter;
 import org.jacoco.core.analysis.ILine;
+import org.jacoco.core.internal.analysis.CounterImpl;
 
 public class LineCoverageCoder {
   
@@ -22,6 +23,18 @@ public class LineCoverageCoder {
     return code;
   }
   
+  public int encode(int ic, int im, int bc, int bm) {
+    int code = 0;
+    code = code | ic;
+    code = code << SHIFT;
+    code = code | im;
+    code = code << SHIFT;
+    code = code | bc;
+    code = code << SHIFT;
+    code = code | bm;
+    return code;
+  }
+  
   public int[] decode(int code) {
     int bm = code & MASK;
     code = code >>> SHIFT;
@@ -32,6 +45,16 @@ public class LineCoverageCoder {
     int ic = code & MASK;
     
     return new int[] {ic, im, bc, bm};
+  }
+  
+  public int decodeStatus(int[] counters) {
+    int bm = counters[3];
+    int bc = counters[2];
+    int im = counters[1];
+    int ic = counters[0];
+    ICounter insnCounter = CounterImpl.getInstance(im, ic);
+    ICounter branchCounter = CounterImpl.getInstance(bm, bc);
+    return insnCounter.getStatus() | branchCounter.getStatus();
   }
 
 }

--- a/src/main/java/org/spideruci/tacoco/reporting/data/SourceFileCoverage.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/data/SourceFileCoverage.java
@@ -7,15 +7,17 @@ public class SourceFileCoverage<T> {
   private final String packagename;
   private final String sessionName;
   private final LineCoverageFormat format;
-  private final int firstLine;
+  private final int firstLine, lastLine;
   private final T[] lines;
   
   SourceFileCoverage(String fileName, String packageName, String sessionName, 
-      int firstLine, LineCoverageFormat format, T[] linesCoverage) {
+      int firstLine, int lastLine, LineCoverageFormat format, 
+      T[] linesCoverage) {
     this.name = fileName;
     this.packagename = packageName;
     this.sessionName = sessionName;
     this.firstLine = firstLine;
+    this.lastLine = lastLine;
     this.format = format;
     this.lines = linesCoverage;
   }
@@ -60,6 +62,13 @@ public class SourceFileCoverage<T> {
    */
   public T[] getLinesCoverage() {
     return lines;
+  }
+
+  /**
+   * @return the lastLine
+   */
+  public int getLastLine() {
+    return lastLine;
   }
 
   public static enum LineCoverageFormat {

--- a/src/main/java/org/spideruci/tacoco/reporting/data/SourceFileCoverage.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/data/SourceFileCoverage.java
@@ -1,18 +1,20 @@
 package org.spideruci.tacoco.reporting.data;
 
 
-public class SourceFileCoverage {
+public class SourceFileCoverage<T> {
   
   private final String name;
   private final String packagename;
+  private final String sessionName;
   private final LineCoverageFormat format;
   private final int firstLine;
-  private final int[] lines;
+  private final T[] lines;
   
-  SourceFileCoverage(String fileName, String packageName, int firstLine, 
-      LineCoverageFormat format, int[] linesCoverage) {
+  SourceFileCoverage(String fileName, String packageName, String sessionName, 
+      int firstLine, LineCoverageFormat format, T[] linesCoverage) {
     this.name = fileName;
     this.packagename = packageName;
+    this.sessionName = sessionName;
     this.firstLine = firstLine;
     this.format = format;
     this.lines = linesCoverage;
@@ -30,6 +32,13 @@ public class SourceFileCoverage {
    */
   public String getPackageName() {
     return packagename;
+  }
+  
+  /**
+   * @return the sessionName
+   */
+  public String getSessionName() {
+    return sessionName;
   }
 
   /**
@@ -49,7 +58,7 @@ public class SourceFileCoverage {
   /**
    * @return the linesCoverage
    */
-  public int[] getLinesCoverage() {
+  public T[] getLinesCoverage() {
     return lines;
   }
 

--- a/src/main/java/org/spideruci/tacoco/reporting/data/SourceFileCoverage.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/data/SourceFileCoverage.java
@@ -10,6 +10,13 @@ public class SourceFileCoverage<T> {
   private final int firstLine, lastLine;
   private final T[] lines;
   
+  public SourceFileCoverage() {
+    lines = null;
+    format = null;
+    firstLine = lastLine = -1;
+    name = packagename = sessionName = null;
+  }
+  
   SourceFileCoverage(String fileName, String packageName, String sessionName, 
       int firstLine, int lastLine, LineCoverageFormat format, 
       T[] linesCoverage) {

--- a/src/main/java/org/spideruci/tacoco/reporting/data/SourceFileCoverageBuilder.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/data/SourceFileCoverageBuilder.java
@@ -8,15 +8,40 @@ import org.jacoco.core.analysis.ISourceFileCoverage;
 import org.spideruci.tacoco.reporting.data.SourceFileCoverage.LineCoverageFormat;
 
 public class SourceFileCoverageBuilder {
-  
-  public static SourceFileCoverage buildCompact(ISourceFileCoverage coverage) {
+
+  public static 
+  SourceFileCoverage<ILine> buildLoose(ISourceFileCoverage coverage, 
+      String sessionName) {
     String packageName = coverage.getPackageName();
     String sourcefileName = coverage.getName();
     int firstLine = coverage.getFirstLine();
     int lastLine = coverage.getLastLine();
-    int[] linesCoverage = null;
+    ILine[] linesCoverage = null;
     if(firstLine != -1) {
-      linesCoverage = new int[lastLine - firstLine + 1];
+      linesCoverage = new ILine[lastLine - firstLine + 1];
+      int counter = 0;
+      for(int i = firstLine; i <= lastLine; i += 1) {
+        linesCoverage[counter] = coverage.getLine(i);
+        counter += 1;
+      }
+    }
+    
+    SourceFileCoverage<ILine> cov = 
+        new SourceFileCoverage<>(sourcefileName, packageName, sessionName, 
+            firstLine, LineCoverageFormat.LOOSE, linesCoverage);
+    return cov;
+  }
+  
+  public static 
+  SourceFileCoverage<Integer> buildCompact(ISourceFileCoverage coverage, 
+      String sessionName) {
+    String packageName = coverage.getPackageName();
+    String sourcefileName = coverage.getName();
+    int firstLine = coverage.getFirstLine();
+    int lastLine = coverage.getLastLine();
+    Integer[] linesCoverage = null;
+    if(firstLine != -1) {
+      linesCoverage = new Integer[lastLine - firstLine + 1];
       LineCoverageCoder coder = new LineCoverageCoder();
       int counter = 0;
       for(int i = firstLine; i <= lastLine; i += 1) {
@@ -26,12 +51,15 @@ public class SourceFileCoverageBuilder {
       }
     }
     
-    SourceFileCoverage cov = new SourceFileCoverage(sourcefileName, 
-        packageName, firstLine, LineCoverageFormat.COMPACT, linesCoverage);
+    SourceFileCoverage<Integer> cov = 
+        new SourceFileCoverage<>(sourcefileName, packageName, sessionName, 
+            firstLine, LineCoverageFormat.COMPACT, linesCoverage);
     return cov;
   }
   
-  public static SourceFileCoverage buildDense(ISourceFileCoverage coverage) {
+  public static 
+  SourceFileCoverage<Integer> buildDense(ISourceFileCoverage coverage,
+      String sessionName) {
     String packageName = coverage.getPackageName();
     String sourcefileName = coverage.getName();
     int firstLine = coverage.getFirstLine();
@@ -41,16 +69,20 @@ public class SourceFileCoverageBuilder {
     if(firstLine != -1) {
       for(int i = firstLine; i <= lastLine; i += 1) {
         linesCoverage.add(coverage.getLine(i));
-      }      
+      }
     }
     
     LinesStatusCoder coder = new LinesStatusCoder();
-    int[] lineStatuses = coder.encode(linesCoverage);
-    SourceFileCoverage cov = new SourceFileCoverage(sourcefileName, 
-        packageName, firstLine, LineCoverageFormat.DENSE, lineStatuses);
+    int[] statuses = coder.encode(linesCoverage);
+    Integer[] lineStatuses = new Integer[statuses.length];
+    int count = 0;
+    for(int status : statuses) {
+      lineStatuses[count++] = status;
+    }
+    
+    SourceFileCoverage<Integer> cov = 
+        new SourceFileCoverage<>(sourcefileName, packageName, sessionName, 
+            firstLine, LineCoverageFormat.DENSE, lineStatuses);
     return cov;
   }
-  
-  
-
 }

--- a/src/main/java/org/spideruci/tacoco/reporting/data/SourceFileCoverageBuilder.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/data/SourceFileCoverageBuilder.java
@@ -28,7 +28,7 @@ public class SourceFileCoverageBuilder {
     
     SourceFileCoverage<ILine> cov = 
         new SourceFileCoverage<>(sourcefileName, packageName, sessionName, 
-            firstLine, LineCoverageFormat.LOOSE, linesCoverage);
+            firstLine, lastLine, LineCoverageFormat.LOOSE, linesCoverage);
     return cov;
   }
   
@@ -53,7 +53,7 @@ public class SourceFileCoverageBuilder {
     
     SourceFileCoverage<Integer> cov = 
         new SourceFileCoverage<>(sourcefileName, packageName, sessionName, 
-            firstLine, LineCoverageFormat.COMPACT, linesCoverage);
+            firstLine, lastLine, LineCoverageFormat.COMPACT, linesCoverage);
     return cov;
   }
   
@@ -82,7 +82,7 @@ public class SourceFileCoverageBuilder {
     
     SourceFileCoverage<Integer> cov = 
         new SourceFileCoverage<>(sourcefileName, packageName, sessionName, 
-            firstLine, LineCoverageFormat.DENSE, lineStatuses);
+            firstLine, lastLine, LineCoverageFormat.DENSE, lineStatuses);
     return cov;
   }
 }

--- a/src/test/java/org/spideruci/tacoco/reporting/TestDoubleObjectReader.java
+++ b/src/test/java/org/spideruci/tacoco/reporting/TestDoubleObjectReader.java
@@ -1,0 +1,69 @@
+package org.spideruci.tacoco.reporting;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.spideruci.tacoco.reporting.CoverageJsonReader;
+
+import com.google.gson.Gson;
+
+@RunWith(Parameterized.class)
+public class TestDoubleObjectReader {
+  
+  @Parameters
+  public static Collection<Object[]> data() {
+    ArrayList<Object[]> integers = new ArrayList<>();
+    int[] array = new int[] {0, 1, 2, -1, -2, -3, 100, 200, -100, -200, 
+        Integer.MAX_VALUE, Integer.MAX_VALUE - 1, Integer.MAX_VALUE - 10, 
+        Integer.MIN_VALUE, Integer.MIN_VALUE + 1,Integer.MIN_VALUE + 10};
+    for(int i : array ) {
+      integers.add(new Object[] { i });
+    }
+    
+    return integers;
+  }
+  
+  private int x;
+  
+  public TestDoubleObjectReader(int num) {
+    x = num;
+  }
+
+  @Test
+  public void shouldReadOriginalIntAfterDeserializationAsObject() {
+    //given
+    Object obj = (Object) x;
+    String json = new Gson().toJson(obj);
+    CoverageJsonReader reader = new CoverageJsonReader(null);
+    
+    //when
+    Object fromJson = new Gson().fromJson(json, Object.class);
+    int y = reader.readDoubleObjectAsInt(fromJson);
+    
+    //then
+    assertEquals(x, y);
+  }
+  
+  @Test
+  public void shouldReadOriginalIntArrayElementAfterDeserializationAsObject() {
+    //given
+    Object obj = new Object[] { (Object) x };
+    String json = new Gson().toJson(obj);
+    CoverageJsonReader reader = new CoverageJsonReader(null);
+    
+    //when
+    Object[] fromJson = new Gson().fromJson(json, Object[].class);
+    Object element = fromJson[0];
+    int y = reader.readDoubleObjectAsInt(element);
+    
+    //then
+    assertEquals(x, y);
+  }
+
+}


### PR DESCRIPTION
Coverage Json-file Reader; Ref. Issue #8
- Added ability to read the exec json-dump (from ExecAnalyzer).
- Json reading utility is contained within `CoverageJsonReader.java`
- Exec json-dump is read in as a coverage matrix with test-cases as rows and source-statements as columns.
- Coverage matrix is modelled in `CoverageMatrix.java`
- Json reading utility, interfaces with the json-dump, **not** directly with the ExecAnalyzer.
