### PR TITLE
Imported and Implemented MavenEmbedder in Tacoco Launcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ local.properties
 # R script
 *.R
 
+# IntelliJ
+*.iml
+
 cp.txt
 lib/*
 tacoco_output/*

--- a/pom.xml
+++ b/pom.xml
@@ -15,12 +15,41 @@
 	<name>tacoco the per testcase junit runner</name>
 	<url></url>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- We inline Maven's dependency management section to align dependency
+                versions from Maven's core -->
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven</artifactId>
+                <version>3.3.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+
 	<dependencies>
-		<dependency>
-			<groupId>org.jacoco</groupId>
-			<artifactId>jacoco-maven-plugin</artifactId>
-			<version>0.7.4.201502262128</version>
-		</dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-embedder</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.wagon</groupId>
+            <artifactId>wagon-http</artifactId>
+            <version>2.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.aether</groupId>
+            <artifactId>aether-transport-wagon</artifactId>
+            <version>1.0.2.v20150114</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.aether</groupId>
+            <artifactId>aether-connector-basic</artifactId>
+            <version>1.0.2.v20150114</version>
+        </dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
@@ -63,7 +92,11 @@
 			<artifactId>sqlite-jdbc</artifactId>
 			<version>3.8.11.1</version>
 		</dependency>
-
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.7.4.201502262128</version>
+        </dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
**.gitignore**
Added iml files since I use IntelliJ :)

**pom.xml**

-Added the required dependencies for Maven Embedder 
-Moved the jacoco maven dependency to the bottom. Since the DefaultPlexusContainer referenced by jacoco plugin conflicts with that of maven embedder. Jacoco plugin depends on ancient libraries :\

**TacocoLauncher.java**
- Setting the "maven.multiModuleProjectDirectory" property as maven versions above 3.3.1 require it to be set. This is seen in the Maven program as well above versions 3.3.1
- Using MavenCli :)
