### PR TITLE
Changing Log Levels of SLFJ-Simple via properties

### DIFF
--- a/src/main/resources/simplelogger.properties
+++ b/src/main/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.defaultLogLevel=error


### PR DESCRIPTION
- While I wasn't able to find a way to toggle logging. We can still change the logging levels. 
- SLF4j-simple has an implementation where it automatically checks for properties in a file named simplelogger.properties. (It also checks System proeprties, But I thought this was a better approach)
- I have currently set the logging level to Error. In this level, only the logs pertaining to error sceanrios get printed on the server. If our application runs fine, Then is as good as no logging :)
