### PR TITLE
Fix broken tacoco build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 	<repositories>
 		<repository>
 			<id>repo.gradle.org</id>
-			<url>http://repo.gradle.org/gradle/libs-releases-local</url>
+			<url>https://repo.gradle.org/gradle/libs-releases/</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Updated the gradle url in pom.xml, the old one was broken and didn't allow us to compile tacoco.