### PR TITLE
Fix travis build error.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
 
 jdk: 
-- oraclejdk8
-- oraclejdk7
+- openjdk8
+- openjdk7
 
 before_install:
 - git clone https://github.com/inf295uci-2015/primitive-hamcrest.git  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: xenial
+
 language: java
 
 jdk: 


### PR DESCRIPTION
Travis CI changed their default build distribution a while back, as a result OracleJDK7 and 8 are not supported anymore. As a result, I would suggest we move to OpenJDK7 and 8.