### PR TITLE
Travis CI update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
       dist: trusty
     
     - jdk: openjdk8
-      dist: bionic
+      dist: xenial
     
     allow_failures:
     - jdk: openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: java
 matrix:
     fast_finish: true
     include:
-    - jdk: openjdk7
-      dist: trusty
-    
     - jdk: openjdk8
       dist: xenial
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
-dist: xenial
-
 language: java
 
-jdk: 
-- openjdk8
-- openjdk7
+matrix:
+    fast_finish: true
+    include:
+    - jdk: openjdk7
+      dist: trusty
+    
+    - jdk: openjdk8
+      dist: bionic
+    
+    allow_failures:
+    - jdk: openjdk11
+      dist: bionic
 
 before_install:
 - git clone https://github.com/inf295uci-2015/primitive-hamcrest.git  


### PR DESCRIPTION
Made three changes to the travis CI:
1. Updated the travis ci to have a configuration for each version of the JDK we want to test.
2. Added openjdk11 configuration (that is allowed to fail), so we can start focussing on adding support for future java versions.
3. Removed Java 7 support. It has reached end of life in April 2015 [source](https://java.com/en/download/faq/java_7.xml)