### PR TITLE
Updated gradle-toolin-api to newest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>org.gradle</groupId>
             <artifactId>gradle-tooling-api</artifactId>
-            <version>2.6</version>
+            <version>6.2.1</version>
         </dependency>
 	</dependencies>
 


### PR DESCRIPTION
Currently the gradle-tooling-api dependency is trailing (2.6 vs 6.2.1), resulting in errors when trying to run tacoco on a gradle project. By updating to the latest version this problem is solved.