### PR TITLE
Bug in GradleModule implementation

### DIFF
--- a/src/main/java/org/spideruci/tacoco/module/GradleModule.java
+++ b/src/main/java/org/spideruci/tacoco/module/GradleModule.java
@@ -135,6 +135,7 @@ public class GradleModule extends AbstractModule {
         return new PathBuilder().path(targetDir).
                 path("build").
                 path("classes").
+                path("java").
                 path("test").buildFilePath();
     }
 
@@ -143,6 +144,7 @@ public class GradleModule extends AbstractModule {
         return new PathBuilder().path(targetDir).
                 path("build").
                 path("classes").
+                path("java").
                 path("main").buildFilePath();
     }
 


### PR DESCRIPTION
Seems like a small bug, but Gradle places its production and test classes in respectively build/classes/java/main and build/classes/java/test. When changing then tacoco can find the tests in the small gradle demo in resources (see the end2end test provided in #99).