### PR TITLE
consuming-projects4testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.class
 *swp
 /target
+projects4testing/
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/

--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+<!-- Based on solutions offered at
+    1. https://blog.travis-ci.com/2017-03-30-deploy-maven-travis-ci-packagecloud/
+    2. https://xebia.com/blog/unpacking-the-possibilities-of-github-packages/
+-->
+
+    <activeProfiles>
+    <activeProfile>github</activeProfile>
+    </activeProfiles>
+
+    <profiles>
+    <profile>
+        <id>github</id>
+        <repositories>
+            <repository>
+            <id>github</id>
+            <name>GitHub spideruci Apache Maven Packages</name>
+            <url>https://maven.pkg.github.com/spideruci/projects4testing</url>
+            </repository>
+        </repositories>
+    </profile>
+    </profiles>
+
+  <servers>
+    <server>
+        <id>github</id>
+        <username>vijay.0288@gmail.com</username>
+        <password>${env.GH_TOKEN}</password>
+      </server>
+  </servers>
+</settings>

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
       dist: bionic
 
 before_install:
-- git clone https://github.com/spideruci/projects4testing.git
 - git clone https://github.com/spideruci/primitive-hamcrest.git
 - cd primitive-hamcrest  
 - mvn install

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,8 @@ before_install:
 - mvn install
 - cd ..
 
+install:
+- cp .travis.settings.xml $HOME/.m2/settings.xml
+
 script:
 - mvn clean integration-test

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,17 @@
 			<id>repo.gradle.org</id>
 			<url>https://repo.gradle.org/gradle/libs-releases/</url>
 		</repository>
+		<repository>
+			<id>github-projects4testing</id>
+			<name>github projects4testing</name>
+			<url>https://maven.pkg.github.com/spideruci/projects4testing</url>
+			<releases>
+			  <enabled>true</enabled>
+			</releases>
+			<snapshots>
+			  <enabled>true</enabled>
+			</snapshots>
+		</repository>
 	</repositories>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,14 @@
 	<version>0.1</version>
 	<packaging>jar</packaging>
 
+	<!-- Used with `mvn deploy` -->
+	<distributionManagement>
+		<repository>
+		  <id>github</id>
+		  <name>GitHub spideruci Apache Maven Packages</name>
+		  <url>https://maven.pkg.github.com/spideruci/tacoco</url>
+		</repository>
+	 </distributionManagement>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -246,6 +254,36 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>3.1.2</version>
+				<executions>
+				  <execution>
+					<id>unpack</id>
+					<phase>package</phase>
+					<goals>
+					  <goal>unpack</goal>
+					</goals>
+					<configuration>
+					  <artifactItems>
+						<artifactItem>
+						  <groupId>org.spideruci.projects4testing</groupId>
+						  <artifactId>projects4testing</artifactId>
+						  <version>1.0.0</version>
+						  <type>jar</type>
+						  <overWrite>false</overWrite>
+						  <outputDirectory>${project.basedir}/projects4testing</outputDirectory>
+						  <destFileName>projects4testing.jar</destFileName>
+						</artifactItem>
+					  </artifactItems>
+					  <outputDirectory>${project.basedir}/projects4testing</outputDirectory>
+					  <overWriteReleases>false</overWriteReleases>
+					  <overWriteSnapshots>true</overWriteSnapshots>
+					</configuration>
+				  </execution>
+				</executions>
+			  </plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
1. Consuming projects4testing:1.0.0 as a jar file, which is then unpacked
    with the maven-dependency-plugin as part of mvn:package.
    This will then be used by mvn:integration-test to run tests on sample projects.
    `projects4testing`'s maven repo is distributed via Github Packages
2. Removing git clone projects4testing from tavisCI. `mvn clean integration-test`
    should now be self contained.
3. Ignoring projects4testing/ locally in git

** Why do this? **
1. This removes the requirement to clone the entire project4testing repo by TravisCI.
2. `mvn install|package` work just the same locally as they do on TravisCI.
3. Aside: Projects `tacoco` and `projects4testing` are now configured with distributionManagement in their build script to be deployed to Github.

Devs running mvn commands on Tacoco will need to replicate what is available in .travis.settings.xml to their own setting.xml file of choice (typically $HOME/.m2/settings.xml) and setup their own Github Token in that file.