### PR TITLE
Added support for analyzing the exec file for multiple modules.

### DIFF
--- a/configs/tacoco-analyzer.config
+++ b/configs/tacoco-analyzer.config
@@ -1,6 +1,6 @@
 # Use these configurations to test tacoco with the spiderMath project in the resources directory,
 # otherwise, set the paths to the exec and jar files appropriately.
--javaagent:$TACOCO_HOME$/lib/org.jacoco.agent-0.8.5-runtime.jar=destfile=$OUTDIR$/$PROJECT_NAME$.exec,dumponexit=false
+-javaagent:$TACOCO_HOME$/lib/org.jacoco.agent-0.8.5-runtime.jar=destfile=$OUTDIR$/$PROJECT_NAME$.exec,dumponexit=true
 -Dtacoco.listeners=org.spideruci.tacoco.testlisteners.JacocoListener
 -Dtacoco.analyzer=org.spideruci.tacoco.analysis.TacocoAnalyzer
--Dtacoco.db
+# -Dtacoco.db

--- a/src/main/java/org/spideruci/tacoco/reporting/ExecAnalyzer.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/ExecAnalyzer.java
@@ -11,6 +11,7 @@ import static org.spideruci.tacoco.cli.AnalyzerCli.readArgumentValue;
 import static org.spideruci.tacoco.cli.AnalyzerCli.readOptionalArgumentValue;
 import static org.spideruci.tacoco.cli.AbstractCli.readBooleanArgument;
 import static org.spideruci.tacoco.reporting.ExecDataPrintManager.createPrintManager;
+import org.spideruci.tacoco.probe.AbstractBuildProbe;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -43,7 +44,7 @@ public final class ExecAnalyzer {
 	private static ExecAnalyzer processArgs(String[] args) {
 
 		String sut = readArgumentValue(SUT);
-		File projectRoot = new File(sut);
+		AbstractBuildProbe projectRoot = AbstractBuildProbe.getInstance(sut);
 
 		String exec = readArgumentValue(EXEC);
 		File execFile = new File(exec);


### PR DESCRIPTION
Currently, the analyzer profile can only deal with projects that consist of a single module. The changes in this pull request clean up some old code, and allow us to analyze an exec file that covers multiple modules. 

