### PR TITLE
Fixed bug of missing execution information for line coverage

### DIFF
--- a/configs/tacoco-analyzer.config
+++ b/configs/tacoco-analyzer.config
@@ -3,4 +3,4 @@
 -javaagent:$TACOCO_HOME$/lib/org.jacoco.agent-0.8.5-runtime.jar=destfile=$OUTDIR$/$PROJECT_NAME$.exec,dumponexit=false
 -Dtacoco.listeners=org.spideruci.tacoco.testlisteners.JacocoListener
 -Dtacoco.analyzer=org.spideruci.tacoco.analysis.TacocoAnalyzer
--Dtacoco.db
+# -Dtacoco.db

--- a/src/main/java/org/spideruci/tacoco/analysis/TacocoAnalyzer.java
+++ b/src/main/java/org/spideruci/tacoco/analysis/TacocoAnalyzer.java
@@ -62,8 +62,10 @@ public class TacocoAnalyzer extends AbstractRuntimeAnalyzer {
 					dbFile.delete();
 				}
 				CreateSQLiteDB.dump(dbFileName, sutHome, exec.toString());
+
+				// Remove exec file only if the content is placed in the database, else keep it!
+				exec.delete();
 			}
-			exec.delete();
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
@@ -73,5 +75,4 @@ public class TacocoAnalyzer extends AbstractRuntimeAnalyzer {
 	public String getName() {
 		return "TACOCO";
 	}
-
 }

--- a/src/main/java/org/spideruci/tacoco/reporting/ExecutionDataParser.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/ExecutionDataParser.java
@@ -37,12 +37,11 @@ public class ExecutionDataParser implements IExecutionDataVisitor {
 		tempDirRef = null;
 	}
 
+	@Override
 	public void visitClassExecution(final ExecutionData data) {
-		if(data == null) return;
-		//    System.out.printf("adding exec-data for: %s %d%n", 
-		//        data.getName(), 
-		//        getHitCount(data.getProbes()));
-		execDataStore.put(data);
+		if(data != null){
+			execDataStore.put(data);
+		}
 	}
 
 	public void resetExecDataStore(String nextSessionName) {
@@ -120,7 +119,4 @@ public class ExecutionDataParser implements IExecutionDataVisitor {
 	public void close() {
 		this.printManager.closeJsonStream();
 	}
-
-
-
 }


### PR DESCRIPTION
We delete the exec file at the end of the execution, this is now only done if we write the exec data to a database.