### PR TITLE
Ignore container events for the unifiedtestlistener

### DIFF
--- a/src/main/java/org/spideruci/tacoco/testlisteners/UnifiedTestListenerAdapter.java
+++ b/src/main/java/org/spideruci/tacoco/testlisteners/UnifiedTestListenerAdapter.java
@@ -22,36 +22,41 @@ public class UnifiedTestListenerAdapter implements TestExecutionListener {
 
     @Override
     public void executionStarted(final TestIdentifier testIdentifier) {
-        if (!testIdentifier.isContainer()) {
-            final String testUniqueName = getUniqueTestName(testIdentifier);
-            listener.onTestStart(testUniqueName);
+        if (testIdentifier.isContainer()) {
+            return;
         }
+
+        final String testUniqueName = getUniqueTestName(testIdentifier);
+        listener.onTestStart(testUniqueName);
     }
 
     @Override
     public void executionSkipped(final TestIdentifier testIdentifier, final String reason) {
-        if (!testIdentifier.isContainer()) {
-            listener.onTestSkipped();
+        if (testIdentifier.isContainer()) {
+            return;
         }
+
+        listener.onTestSkipped();
     }
 
     @Override
     public void executionFinished(final TestIdentifier testIdentifier, final TestExecutionResult testExecutionResult) {
-        if (!testIdentifier.isContainer()) {
-            final Status status = testExecutionResult.getStatus();
-
-            switch (status) {
-                case SUCCESSFUL:
-                    listener.onTestPassed();
-                    break;
-                case FAILED:
-                case ABORTED:
-                    listener.onTestFailed();
-                    break;
-            }
-
-            listener.onTestEnd();
+        if (testIdentifier.isContainer()) {
+            return;
         }
+        final Status status = testExecutionResult.getStatus();
+
+        switch (status) {
+            case SUCCESSFUL:
+                listener.onTestPassed();
+                break;
+            case FAILED:
+            case ABORTED:
+                listener.onTestFailed();
+                break;
+        }
+
+        listener.onTestEnd();
     }
 
     public void testPlanExecutionStarted(final TestPlan testPlan) {

--- a/src/main/java/org/spideruci/tacoco/testlisteners/UnifiedTestListenerAdapter.java
+++ b/src/main/java/org/spideruci/tacoco/testlisteners/UnifiedTestListenerAdapter.java
@@ -22,30 +22,36 @@ public class UnifiedTestListenerAdapter implements TestExecutionListener {
 
     @Override
     public void executionStarted(final TestIdentifier testIdentifier) {
-        final String testUniqueName = getUniqueTestName(testIdentifier);
-        listener.onTestStart(testUniqueName);
+        if (!testIdentifier.isContainer()) {
+            final String testUniqueName = getUniqueTestName(testIdentifier);
+            listener.onTestStart(testUniqueName);
+        }
     }
 
     @Override
     public void executionSkipped(final TestIdentifier testIdentifier, final String reason) {
-        listener.onTestSkipped();
+        if (!testIdentifier.isContainer()) {
+            listener.onTestSkipped();
+        }
     }
 
     @Override
     public void executionFinished(final TestIdentifier testIdentifier, final TestExecutionResult testExecutionResult) {
-        final Status status = testExecutionResult.getStatus();
+        if (!testIdentifier.isContainer()) {
+            final Status status = testExecutionResult.getStatus();
 
-        switch (status) {
-        case SUCCESSFUL:
-            listener.onTestPassed();
-            break;
-        case FAILED:
-        case ABORTED:
-            listener.onTestFailed();
-            break;
+            switch (status) {
+                case SUCCESSFUL:
+                    listener.onTestPassed();
+                    break;
+                case FAILED:
+                case ABORTED:
+                    listener.onTestFailed();
+                    break;
+            }
+
+            listener.onTestEnd();
         }
-
-        listener.onTestEnd();
     }
 
     public void testPlanExecutionStarted(final TestPlan testPlan) {


### PR DESCRIPTION
Made a change that all the container events are filtered out, and we only care about the actual tests.

I am not sure if this is something we care about, however, the JUnit platform has events for two types of components: (1) a container, and (2) tests. For a testlistener we probably care only about the latter.

Do you have any thoughts on this?