### PR TITLE
Bug in reader

### DIFF
--- a/src/main/java/org/spideruci/tacoco/reporting/CoverageJsonReader.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/CoverageJsonReader.java
@@ -216,7 +216,11 @@ public class CoverageJsonReader {
 	private int[] getLineCoverage(LineCoverageFormat covFormat, 
 			LineCoverageCoder coder, SourceFileCoverage sourcefile) {
 		ArrayList<Integer> lineCoverages = new ArrayList<>();
-		for(Object line : sourcefile.getLinesCoverage()) {
+
+		Object[] lines = sourcefile.getLinesCoverage();
+		assert lines != null;
+		
+		for(Object line : lines) {
 			if(covFormat == LineCoverageFormat.LOOSE) {
 				Map insnCounter = (Map) ((Map)line).get("instructions");
 				int ic = readDoubleObjectAsInt(insnCounter.get("covered"));

--- a/src/main/java/org/spideruci/tacoco/reporting/CoverageJsonReader.java
+++ b/src/main/java/org/spideruci/tacoco/reporting/CoverageJsonReader.java
@@ -198,9 +198,12 @@ public class CoverageJsonReader {
 				int lastLine = sourcefile.getLastLine();
 				SourceFile source = new SourceFile(filename, firstLine, lastLine);
 
-				int[] codedLineCoverage = getLineCoverage(covFormat, coder, sourcefile);
-
-				covMat.addStmtCoverage(source, testCaseName, codedLineCoverage);
+				if (sourcefile.getLinesCoverage() != null) {
+					int[] codedLineCoverage = getLineCoverage(covFormat, coder, sourcefile);
+					covMat.addStmtCoverage(source, testCaseName, codedLineCoverage);
+				} else {
+					System.err.printf("[DEBUG] Sourcefile %s, has no lines that are covered...%n", filename);
+				}
 			}
 			this.endReadingTestCase();
 			System.out.println();


### PR DESCRIPTION
If sourcefile coverage doesn't contain any lines we shouldn't try to add it to the coverage matrix (it causes a null pointer exception).

I ran tacoco on [commons-io](https://github.com/apache/commons-io) using the following commands:

```
mvn exec:java -Plauncher -Dtacoco.sut=$project -Dtacoco.home=$TACOCO_HOME -Dtacoco.project=$project_name -Danalyzer.opts="configs/tacoco-analyzer.config"

mvn exec:java -Panalyzer -Dtacoco.sut=$project -Dtacoco.exec=tacoco_output/$project_name.exec -Dtacoco.json=tacoco_output/$project_name.json

mvn exec:java -Preader -Dtacoco.json=tacoco_output/$project_name.json
```

The final step would crash, due to a null pointer exception. It seems the problem lies in a few files being outputted like this by the analyzer:

```
 {
    "name": "FileAlterationListener.java",
    "packagename": "org/apache/commons/io/monitor",
    "sessionName": "testFileCleanerDirectory().[engine:junit-jupiter]/[class:org.apache.commons.io.FileCleaningTrackerTestCase]/[method:testFileCleanerDirectory()]",
    "format": "LOOSE",
    "firstLine": -1,
    "lastLine": -1
},

As a result, when reading this and trying to output the line coverage for each test case it crashes because when converting the json to object the lines attribute was initialized to null.
```