### PR TITLE
Update pom.xml to make installing easier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
 				<executions>
 				  <execution>
 					<id>unpack</id>
-					<phase>package</phase>
+					<phase>integration-test</phase>
 					<goals>
 					  <goal>unpack</goal>
 					</goals>


### PR DESCRIPTION
The current implementation splits the downloading and unpacking of the projects4testing jar and using it in the integration-test into two different phases (respectively package and integration-test). As a result, if someone wants to quickly install it without running the integration tests and not modifying the .m2/settings.xml to allow for downloading the projects4testing.jar it fail.

I moved this both to the integration-test phase, so if we skip the integration-test phase it also skips downloading the projects4testing.jar.